### PR TITLE
fix some tokenswap bug

### DIFF
--- a/contracts/merkleTree2.scrypt
+++ b/contracts/merkleTree2.scrypt
@@ -3,6 +3,7 @@ contract MerkleTree {
     static function calculateMerkleRoot(bytes leaf, bytes merklePath) : bytes {
         int i = 0;
         int merklePathLength = len(merklePath) / 33;
+        require(merklePathLength <= 5);
         bytes merkleValue = leaf;
         loop (5) {
             if (i < merklePathLength) {

--- a/contracts/tokenSwap.scrypt
+++ b/contracts/tokenSwap.scrypt
@@ -362,11 +362,11 @@ contract TokenSwap {
         bool poolIsLeft,
         int bsvAmount) {
         // check preimage with sighash_all
-        //SigHashType sigHashType = SigHash.SINGLE | SigHash.FORKID;
-        //require(Util.checkPreimageSigHashType(txPreimage, sigHashType));
+        SigHashType sigHashType = SigHash.SINGLE | SigHash.FORKID;
+        require(Util.checkPreimageSigHashType(txPreimage, sigHashType));
 
-        //// check sender sig
-        //require(checkSig(senderSig, sender));
+        // check sender sig
+        require(checkSig(senderSig, sender));
 
         // get the tokenMerkleRoot
         bytes lockingScript = Util.scriptCode(txPreimage);


### PR DESCRIPTION
1 tokenSwap.swapBsvToToken need check preimage. 
2 check max height when calculate merkle tree root.