### PR TITLE
Adding HashPuzzle contract

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,6 +75,19 @@
     {
       "type": "scrypt",
       "request": "launch",
+      "name": "Debug HashPuzzle",
+      "program": "${workspaceFolder}/contracts/hashpuzzle.scrypt",
+      "constructorParams": [
+        "Sha256(b'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')"
+      ],
+      "entryMethod": "verify",
+      "entryMethodParams": [
+        "b'616263'"
+      ]
+    },
+    {
+      "type": "scrypt",
+      "request": "launch",
       "name": "Debug Ackermann",
       "program": "${workspaceFolder}/contracts/ackermann.scrypt",
       "constructorParams": [

--- a/contracts/hashpuzzle.scrypt
+++ b/contracts/hashpuzzle.scrypt
@@ -1,0 +1,17 @@
+/**
+A Bitcoin contract which is instantiated with a shasum of known data
+required to be input to spend the output.
+Demo values:
+sha256("abc") = 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+bytes("abc") = 0x616263
+**/
+
+// Main Data Check
+contract HashPuzzle {
+    Sha256 hash;
+
+    // Main function verifies the data matches the provided Sha256Sum
+    public function verify(bytes data) {
+        require(sha256(data) == this.hash);
+    }
+}

--- a/deployments/hashpuzzle.js
+++ b/deployments/hashpuzzle.js
@@ -1,0 +1,54 @@
+/**
+ * Testnet test for HashPuzzle contract in JavaScript
+ **/
+const {
+  bsv,
+  buildContractClass,
+  toHex,
+  Bytes,
+  Sha256
+} = require('scryptlib');
+const {
+  loadDesc,
+  createUnlockingTx,
+  createLockingTx,
+  sendTx,
+  showError
+} = require('../helper');
+const {
+  privateKey
+} = require('../privateKey');
+
+// NIST Test Vectors (https://www.nist.gov/itl/ssd/software-quality-group/nsrl-test-data)
+const dataBuffer = Buffer.from("abc");
+const data = dataBuffer
+const sha256Data = bsv.crypto.Hash.sha256(dataBuffer);
+
+(async () => {
+  try {
+    const amount = 1000
+    const newAmount = 546
+
+    const HashPuzzle = buildContractClass(loadDesc('hashpuzzle_desc.json'));
+    const hashPuzzle = new HashPuzzle(new Sha256(toHex(sha256Data)))
+
+    // lock fund to the script
+    const lockingTx = await createLockingTx(privateKey.toAddress(), amount)
+    lockingTx.outputs[0].setScript(hashPuzzle.lockingScript)
+    lockingTx.sign(privateKey)
+    let lockingTxid = await sendTx(lockingTx)
+    console.log('funding txid:      ', lockingTxid)
+
+    // unlock
+    const unlockingTx = await createUnlockingTx(lockingTxid, amount, hashPuzzle.lockingScript.toASM(), newAmount)
+    const unlockingScript = hashPuzzle.verify(new Bytes(toHex(data))).toScript()
+    unlockingTx.inputs[0].setScript(unlockingScript)
+    const unlockingTxid = await sendTx(unlockingTx)
+    console.log('unlocking txid:   ', unlockingTxid)
+
+    console.log('Succeeded on testnet')
+  } catch (error) {
+    console.log('Failed on testnet')
+    showError(error)
+  }
+})()

--- a/tests/js/hashpuzzle.scrypttest.js
+++ b/tests/js/hashpuzzle.scrypttest.js
@@ -1,0 +1,35 @@
+/**
+ * Test for HashPuzzle contract in JavaScript
+ **/
+const path = require('path');
+const { expect } = require('chai');
+const { bsv, buildContractClass, toHex, Sha256, Bytes } = require('scryptlib');
+const { inputIndex, inputSatoshis, newTx, compileContract } = require('../../helper');
+
+// NIST Test Vectors (https://www.nist.gov/itl/ssd/software-quality-group/nsrl-test-data)
+const dataBuffer = Buffer.from("abc");
+const data =  dataBuffer
+const sha256Data = bsv.crypto.Hash.sha256(dataBuffer);
+
+const tx = newTx();
+
+describe('Test sCrypt contract HashPuzzle In Javascript', () => {
+  let hashPuzzle, result
+
+  before(() => {
+    HashPuzzle = buildContractClass(compileContract('hashpuzzle.scrypt'))
+    hashPuzzle = new HashPuzzle(new Sha256(toHex(sha256Data)))
+    //hashPuzzle.txContext = { tx, inputIndex, inputSatoshis }
+  });
+
+  it('check should succeed when correct data provided', () => {
+    result = hashPuzzle.verify(new Bytes(toHex(data))).verify()
+    expect(result.success, result.error).to.be.true
+  });
+
+  it('check should fail when wrong data provided', () => {
+    result = hashPuzzle.verify(new Bytes(toHex('abcdef'))).verify()
+    expect(result.success, result.error).to.be.false
+  });
+
+});


### PR DESCRIPTION
This is a simple HashPuzzle contract which is based on hashpuzzlep2pkh.scrypt, but without the public key stuff.