### PR TITLE
fix inline asm function bug

### DIFF
--- a/contracts/asm.scrypt
+++ b/contracts/asm.scrypt
@@ -45,9 +45,10 @@ contract Asm {
     }
 
     function lenFail(bytes b) : int {
-        // this is wrong since there are multiple elements on stack upon return
+        // this is wrong since the last value on stack will be considered as the return value
         asm {
             OP_SIZE
+            OP_0
         }
     }
 

--- a/contracts/simpleBVM.scrypt
+++ b/contracts/simpleBVM.scrypt
@@ -165,22 +165,18 @@ contract SimpleBVM {
     function op_fromaltstack() : int {
         asm { 
             OP_FROMALTSTACK
-            OP_0
         }
     }
 
     function op_numequal() : int {
         asm { 
             OP_NUMEQUAL
-            OP_0
         }
     }
 
     function op_verify() : int {
         asm { 
             OP_VERIFY
-            OP_0
-            OP_0
         }
     }
 
@@ -250,7 +246,7 @@ contract SimpleBVM {
 
     function compareResult() : int {
         int x = this.x;
-        this.op_fromaltstack();
+        int nx = this.op_fromaltstack();  // use assignment instead of expression statement to keep the return value on stack
 
         this.op_numequal();
         this.op_verify();


### PR DESCRIPTION
NOW: only the last typed-value generated by inline asm function will be considered as the return value