### PR TITLE
p2npkh contract and tests

### DIFF
--- a/contracts/p2npkh.scrypt
+++ b/contracts/p2npkh.scrypt
@@ -1,0 +1,23 @@
+// Demonstrate "Pay-to-NFT-PubKey-Hash"
+// Reference: https://attilaaf.medium.com/introducing-a-non-fungible-token-standard-for-bitcoin-pay-to-nft-pubkey-hash-p2npkh-a01e41ef82bd
+// Use replaceAsmVars to set the initial $asset and $pkh
+// To deploy an NFT set the $asset to 36 bytes NULL (72 zeroes)
+// and the $pkh to the initial owner/issuer of the asset.
+// Then to mint the NFT, spend to the same script by replacing the $asset
+// value with the outpoint (36 bytes txid+outputIndex) that was spent
+// Use SIGHASH_SINGLE to trace the identity of the asset.
+contract DemoP2NPKH {
+    public function unlock(Sig sig, PubKey pubKey) {
+        asm {
+            $asset
+            OP_TOALTSTACK 
+            OP_DUP 
+            OP_TOALTSTACK 
+            OP_DUP 
+            OP_HASH160 
+            $pkh
+            OP_EQUALVERIFY
+            OP_CHECKSIG
+        }
+    }
+}

--- a/testnet/p2npkh.js
+++ b/testnet/p2npkh.js
@@ -1,0 +1,197 @@
+const { buildContractClass, toHex, signTx, Ripemd160, Sig, PubKey, bsv } = require('scryptlib');
+
+const {
+  deployContract,
+  createInputFromPrevTx,
+  sendTx,
+  showError,
+  loadDesc
+} = require('../helper')
+
+const Signature = bsv.crypto.Signature;
+
+const { privateKey } = require('../privateKey');
+
+function buildNFTPublicKeyHashOut(asset, pkh) {
+  return bsv.Script.fromASM(`${asset} OP_TOALTSTACK OP_DUP OP_TOALTSTACK OP_DUP OP_HASH160 ${pkh} OP_EQUALVERIFY OP_CHECKSIG`);
+}
+
+function buildNFTMintMetadataOpReturn() {
+  return bsv.Script.fromASM(`OP_FALSE OP_RETURN ${Buffer.from("Image: https://i1.sndcdn.com/artworks-000299901567-oiw8tq-t500x500.jpg", 'utf8').toString('hex')}`);
+}
+function buildMetadataOpReturn(someData = 'hello world') {
+  return bsv.Script.fromASM(`OP_FALSE OP_RETURN ${Buffer.from(someData, 'utf8').toString('hex')}`);
+}
+
+const sleeper = async(seconds) => {
+  return new Promise((resolve) => {
+     setTimeout(() => {
+        resolve();
+     }, seconds * 1000);
+  })
+}
+
+/*
+  Example output and transactions....
+
+  node testnet/p2npkh.js
+
+  About to deploy (pre-mint) nft...
+  Deploy txid:      baf89060477742330b119f808710f15df36a1f89b06b722046f334378af17d5b
+  assetId (outpoint):      5b7df18a3734f34620726bb0891f6af35df11087809f110b334277476090f8ba00000000
+
+  About to mint nft...
+  mintTx 01000000015b7df18a3734f34620726bb0891f6af35df11087809f110b334277476090f8ba000000006b483045022100b08709eaf86660ae790e0de48ee63955ee035a2ace72fd6a9ff828f9fe36d05e02207fe9e529766885f6cf9c3a6aaad4b0b8cef9d9aab7ef24db2cb8808d989cd578412103f7b098436ded4a04dfa8bb0069f4e4670d2202f726727f58f610d3b6292af449ffffffff02592600000000000041245b7df18a3734f34620726bb0891f6af35df11087809f110b334277476090f8ba000000006b766b76a914ada084074f9a305be43e3366455db062d6d3669788ac000000000000000049006a46496d6167653a2068747470733a2f2f69312e736e6463646e2e636f6d2f617274776f726b732d3030303239393930313536372d6f69773874712d74353030783530302e6a706700000000
+  Mint txid:  8150c98ab64ba534bd61b104753f01e5449c287d6d87260e83872f713df1aca4
+
+  About to transfer nft...
+  transferTX 0100000001a4acf13d712f87830e26876d7d289c44e5013f7504b161bd34a54bb68ac95081000000006b4830450221008c739d701e9a77e95ee7b8ed2621f20930abf977719eabbea993a3f59c7d0ea5022047186e3e32922e5c871ae3e1fc17acf5357ca3089fe8a3953e9e1fde0ce6ddbb412103f7b098436ded4a04dfa8bb0069f4e4670d2202f726727f58f610d3b6292af449ffffffff02bf2500000000000041245b7df18a3734f34620726bb0891f6af35df11087809f110b334277476090f8ba000000006b766b76a914ada084074f9a305be43e3366455db062d6d3669788ac00000000000000000e006a0b68656c6c6f20776f726c6400000000
+  Transfer txid:  21f5e2c2f5ad7e705c7eb856f8bb03357e0c2aab7746228b32b88b59efbdbed1
+
+  About to melt nft...
+  meltTx 0100000001d1bebdef598bb8328b224677ab2a0c7e3503bbf856b87e5c707eadf5c2e2f521000000006a47304402204c4df14e16a630a3a9a3708492bbad54fad74cc4b9be9914a85959e4bfc5228002207d113c5f5807e982ee97b8a439e8abb9ffd7ac0df8012564d112ab6782def148412103f7b098436ded4a04dfa8bb0069f4e4670d2202f726727f58f610d3b6292af449ffffffff0145250000000000001976a914ada084074f9a305be43e3366455db062d6d3669788ac00000000
+  Melt txid:  991a5aece32f8b5d36fedcd02ea954d467472b949025e3e33f4ffecbe0e9e9fb
+*/
+async function main() {
+  try {
+    const publicKey = privateKey.publicKey
+
+    // Initialize contract
+    const P2NPKH = buildContractClass(loadDesc('p2npkh_debug_desc.json'))
+    const publicKeyHash = bsv.crypto.Hash.sha256ripemd160(publicKey.toBuffer())
+    const nft = new P2NPKH()
+    const asmVars = {
+      'DemoP2NPKH.unlock.pkh': toHex(publicKeyHash),
+      'DemoP2NPKH.unlock.asset': '000000000000000000000000000000000000000000000000000000000000000000000000'
+    };
+    nft.replaceAsmVars(asmVars);
+    const amount = 10000;
+    let nftAmount = amount;
+    // deploy contract on testnet
+    console.log('About to deploy (pre-mint) nft...')
+    const deployTx = await deployContract(nft, amount);
+
+    console.log('Deploy txid:     ', deployTx.id)
+    // We must reverse the endianness of the printed txid to match the outpoint format in the raw tx
+    const mintAssetId = Buffer.from(deployTx.id, 'hex').reverse().toString('hex') + '00000000';
+    console.log('assetId (outpoint):     ', mintAssetId)
+
+    // call contract method on testnet
+    const mintTx = new bsv.Transaction();
+
+    // mint the asset
+    console.log('About to mint nft...')
+    await sleeper(1);
+    mintTx.addInput(createInputFromPrevTx(deployTx))
+    .setOutput(0, (tx) => {
+      // Set the ASM vars manually
+      const asmVars = {
+        'pkh': toHex(privateKey.toAddress()),
+        'asset': mintAssetId
+      };
+      nft.replaceAsmVars(asmVars);
+      const newLockingScript = buildNFTPublicKeyHashOut(mintAssetId, privateKey.toAddress().toHex().substring(2))
+      nftAmount = nftAmount - tx.getEstimateFee();
+      return new bsv.Transaction.Output({
+        script: newLockingScript,
+        satoshis: nftAmount,
+      })
+    })
+    .setOutput(1, (tx) => {
+      const deployData = buildNFTMintMetadataOpReturn()
+      return new bsv.Transaction.Output({
+        script: deployData,
+        satoshis: 0,
+      })
+    })
+    .setInputScript(0, (tx, output) => {
+      const sig = signTx(mintTx, privateKey, output.script, output.satoshis)
+      return nft.unlock(sig, new PubKey(toHex(publicKey))).toScript()
+    })
+    .seal()
+
+    console.log('mintTx', mintTx.toString());
+    const mintTxid = await sendTx(mintTx)
+    console.log('Mint txid: ', mintTxid)
+
+    // Transfer ownership
+    console.log('About to transfer nft...')
+    await sleeper(1);
+    // call contract method on testnet
+    const transferTX = new bsv.Transaction();
+    transferTX.addInput(createInputFromPrevTx(mintTx, 0))
+      .setOutput(0, (tx) => {
+        // Set the ASM vars manually
+        const asmVars = {
+          'pkh': toHex(privateKey.toAddress()),
+          'asset': mintAssetId
+        };
+        nft.replaceAsmVars(asmVars);
+        const newLockingScript = buildNFTPublicKeyHashOut(mintAssetId, privateKey.toAddress().toHex().substring(2))
+        nftAmount = nftAmount - tx.getEstimateFee();
+        return new bsv.Transaction.Output({
+          script: newLockingScript,
+          satoshis: nftAmount, // Set a fee to handle it all
+        })
+      })
+      .setOutput(1, (tx) => {
+        const deployData = buildMetadataOpReturn()
+        return new bsv.Transaction.Output({
+          script: deployData,
+          satoshis: 0,
+        })
+      })
+      .setInputScript(0, (tx, output) => {
+        // Set SIGHASH_SINGLE to ensure identity is traced correctly and no mistakes can be made 
+        // Note: This gives the signing visibility to the i'th output for the i'th input
+        // .... But in practice for p2npkh this does not matter since it is not using OP_PUSH_TX
+        //const sighashType = Signature.SIGHASH_ANYONECANPAY | Signature.SIGHASH_ALL| Signature.SIGHASH_FORKID;
+        const sig = signTx(transferTX, privateKey, output.script, output.satoshis);//, 0, sighashType)
+        return nft.unlock(sig, new PubKey(toHex(publicKey))).toScript()
+      })
+      .seal()
+
+    console.log('transferTX', transferTX.toString());
+    const transferTxid = await sendTx(transferTX)
+    console.log('Transfer txid: ', transferTxid)
+
+    // Transfer ownership
+    console.log('About to melt nft...')
+    await sleeper(1);
+    // call contract method on testnet
+    const meltTX = new bsv.Transaction();
+    meltTX.addInput(createInputFromPrevTx(transferTX, 0))
+      .setOutput(0, (tx) => {
+        // Set the ASM vars manually
+        const asmVars = {
+          'pkh': toHex(privateKey.toAddress()),
+          'asset': mintAssetId
+        };
+        nft.replaceAsmVars(asmVars);
+        const newLockingScript = bsv.Script.buildPublicKeyHashOut(privateKey.toAddress());
+        nftAmount = nftAmount - tx.getEstimateFee();
+        return new bsv.Transaction.Output({
+          script: newLockingScript,
+          satoshis: nftAmount, // Set a fee to handle it all
+        })
+      })
+      .setInputScript(0, (tx, output) => {
+        // Set SIGHASH_SINGLE to ensure identity is traced correctly and no mistakes can be made 
+        // Note: This gives the signing visibility to the i'th output for the i'th input
+        // .... But in practice for p2npkh this does not matter since it is not using OP_PUSH_TX
+        //const sighashType = Signature.SIGHASH_ANYONECANPAY | Signature.SIGHASH_ALL| Signature.SIGHASH_FORKID;
+        const sig = signTx(meltTX, privateKey, output.script, output.satoshis);//, 0, sighashType)
+        return nft.unlock(sig, new PubKey(toHex(publicKey))).toScript()
+      })
+      .seal()
+
+    console.log('meltTx', meltTX.toString());
+    const meltTxid = await sendTx(meltTX)
+    console.log('Melt txid: ', meltTxid)
+  } catch (error) {
+    console.log('Failed on testnet')
+    showError(error)
+  }
+}
+
+main()

--- a/tests/ts/p2npkh.scrypttest.ts
+++ b/tests/ts/p2npkh.scrypttest.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { buildContractClass, signTx, toHex, bsv, Ripemd160, PubKey, Sig, VerifyResult } from 'scryptlib';
+import { compileContract, newTx } from "../../helper";
+
+/**
+ * an example p2npkh test for contract containing signature verification
+ */
+import { inputIndex, inputSatoshis, tx } from '../../helper';
+
+const privateKey = new bsv.PrivateKey.fromRandom('testnet')
+const publicKey = privateKey.publicKey
+const pkh = bsv.crypto.Hash.sha256ripemd160(publicKey.toBuffer())
+const privateKey2 = new bsv.PrivateKey.fromRandom('testnet')
+
+describe('Test sCrypt contract DemoP2NPKH In Typescript', () => {
+  let demo: any;
+  let sig: any;
+  let result: VerifyResult
+  let tx:any = newTx();
+
+  before(() => {
+    const DemoP2PKH = buildContractClass(compileContract('p2npkh.scrypt'))
+    demo = new DemoP2PKH()
+    const publicKeyHash = bsv.crypto.Hash.sha256ripemd160(publicKey.toBuffer())
+    const asmVars = {
+      'DemoP2NPKH.unlock.pkh': toHex(publicKeyHash),
+      'DemoP2NPKH.unlock.asset': '000000000000000000000000000000000000000000000000000000000000000000000000'
+    };
+    demo.replaceAsmVars(asmVars);
+    demo.txContext = {
+      tx,
+      inputIndex,
+      inputSatoshis
+    }
+  });
+
+  it('signature check should succeed when right private key signs', () => {
+    sig = signTx(tx, privateKey, demo.lockingScript, inputSatoshis)
+    result = demo.unlock(new Sig(toHex(sig)), new PubKey(toHex(publicKey))).verify()
+    expect(result.success, result.error).to.be.true
+  });
+
+  it('signature check should fail when wrong private key signs', () => {
+    sig = signTx(tx, privateKey2, demo.lockingScript, inputSatoshis)
+    result = demo.unlock(new Sig(toHex(sig)), new PubKey(toHex(publicKey))).verify()
+    expect(result.success, result.error).to.be.false
+  });
+});


### PR DESCRIPTION
Added new "Pay-to-NFT-PubKey-Hash" (P2NPKH) contract.

>The world’s smallest and most flexible Bitcoin smart contract script to support every Non-Fungible Token (NFT) use-cases.

This is an NFT that does not rely on OP_PUSH_TX but instead of just using a convention.

Features:

- Optimal: smallest possible script size. Avoids OP_PUSH_TX (relies on convention instead)
- Flexible: every use-case must be supported, including unforeseen ones; NFT can be polymorphic or restricted
- Easy Integration: works with simple text editor, easy to understand, debug and adopt in any other module
- Scalable: storage and run-time complexity should be identical to “regular” P2PKH UTXO’s. Parsers should be able to examine the prefix of any output in any transaction in a block and quickly pattern match the first 36+1 bytes or discard it immediately
- Secure: Layer-1 enforced by miners with an impossible to forge NFT asset history using tamper resistant chain of digital signatures
- Compatible: guarantee to work for all applications and every change in the future

## Examples (Testnet)

- Deploy: https://test.whatsonchain.com/tx/baf89060477742330b119f808710f15df36a1f89b06b722046f334378af17d5b 
- Mint: https://test.whatsonchain.com/tx/8150c98ab64ba534bd61b104753f01e5449c287d6d87260e83872f713df1aca4 
- Transfer: https://test.whatsonchain.com/tx/21f5e2c2f5ad7e705c7eb856f8bb03357e0c2aab7746228b32b88b59efbdbed1 
- Melt: https://test.whatsonchain.com/tx/991a5aece32f8b5d36fedcd02ea954d467472b949025e3e33f4ffecbe0e9e9fb 

## Examples (Mainnet)

- Deploy: https://whatsonchain.com/tx/e0ce4df42a6b0ceb374f01325e7f8e1efe2230120333be79f35d5e2ceedbf7ed 
- Mint: https://whatsonchain.com/tx/d2eb2c42e4f779aac1ca45ffc69c1bfb25000e831d238bddf00a9163c820b48b 
- Transfer: https://whatsonchain.com/tx/ad84f4ec53153395afd5b67d9f08ecf6d1fa25c9a4d035e756c03b3f2adcd526 
- Melt: https://whatsonchain.com/tx/a38b0c7134a2dff7b3cdf2fc5b84e8cedde873d6ffff21b1fe7ac1a213091666 
 
Reference: https://attilaaf.medium.com/introducing-a-non-fungible-token-standard-for-bitcoin-pay-to-nft-pubkey-hash-p2npkh-a01e41ef82bd